### PR TITLE
fix: sidebar collapse arrow orientation when collapsed

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": false
+}

--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -9,6 +9,7 @@ type MenuItemProps = {
   iconSrc: string;
   onClick: () => void;
   isCollapsed: boolean;
+  reverseIcon?: boolean;
 };
 
 export function MenuItemButton({
@@ -17,12 +18,17 @@ export function MenuItemButton({
   onClick,
   iconSrc,
   isCollapsed,
+  reverseIcon,
 }: MenuItemProps) {
   return (
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={classNames(styles.icon, reverseIcon && styles.reverse)}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -1,5 +1,6 @@
 @use "@styles/color";
 @use "@styles/space";
+@use "@styles/animations";
 
 .listItem {
   height: space.$s12;
@@ -9,6 +10,11 @@
   padding: space.$s0 space.$s3;
   background: transparent;
   border-radius: 6px;
+  transition: animations.$transition-config;
+
+  &:hover {
+    background-color: color.$gray-700;
+  }
 }
 
 .listItem.active {
@@ -32,5 +38,5 @@
 }
 
 .reverse {
-  transform: rotateY(180deg);
+  transform: rotate(180deg);
 }

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -30,3 +30,7 @@
   width: space.$s6;
   margin-right: space.$s3;
 }
+
+.reverse {
+  transform: rotateY(180deg);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -3,12 +3,14 @@
 @use "@styles/breakpoint";
 @use "@styles/z-index";
 @use "@styles/misc";
+@use "@styles/animations";
 
 .container,
 .fixedContainer {
   width: 100%;
   display: flex;
   flex-direction: column;
+  transition: animations.$transition-config;
 
   @media (min-width: breakpoint.$desktop) {
     width: 17.5rem;
@@ -137,5 +139,9 @@
 
   @media (min-width: breakpoint.$desktop) {
     display: flex;
+
+    img {
+      transition: animations.$transition-config;
+    }
   }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -91,6 +91,7 @@ export function SidebarNavigation() {
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
               className={styles.collapseMenuItem}
+              reverseIcon={isSidebarCollapsed}
             />
           </ul>
         </nav>

--- a/styles/animations.scss
+++ b/styles/animations.scss
@@ -1,0 +1,1 @@
+$transition-config: 200ms ease-in-out;


### PR DESCRIPTION
# Details
- This PR is to fix the bug that the sidebar arrow icon is pointing in the wrong direction when collapsed
- Added a `reverseIcon` prop to conditionally add the new `reverse` class in the `MenuItemButton` component.
- Added prettier config for the project for consistency.
- Added animations for sidebar expanding/closing and hovering of items.
- No tests added since no functionality changed, only style, and a future visual test should be included to make it easier.

# Screenshots
- Expanded view
![image](https://github.com/profydev/prolog-app-cbtsao47/assets/16598376/f4aeb98c-248d-4c79-94f8-b741f462c83a)

- Collapsed view
![image](https://github.com/profydev/prolog-app-cbtsao47/assets/16598376/0e4d6be3-051a-4904-8353-4ac835bc461a)
