### PR TITLE
fix: reduce project card divider thickness

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
## Details

- Card divider was too thick (3px), so I changed it to 1px according to the design.

## Screenshots

- Before
![image](https://github.com/profydev/prolog-app-cbtsao47/assets/16598376/a178d6b1-1cdc-4706-8cd3-a33fd29c2de4)

- After
![image](https://github.com/profydev/prolog-app-cbtsao47/assets/16598376/79e6b731-df27-486c-a85c-58d9777b18ff)
