### PR TITLE
fix: support button not opening client mailer app

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -29,6 +29,14 @@ describe("Sidebar Navigation", () => {
       cy.get("nav")
         .contains("Settings")
         .should("have.attr", "href", "/dashboard/settings");
+
+      cy.get("nav")
+        .contains("Support")
+        .should(
+          "have.attr",
+          "href",
+          "mailto:support@prolog-app.com?subject=Support%20Request",
+        );
     });
 
     it("is collapsible", () => {
@@ -36,7 +44,7 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -80,7 +88,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/features/layout/sidebar-navigation/menu-item-link.tsx
+++ b/features/layout/sidebar-navigation/menu-item-link.tsx
@@ -7,7 +7,7 @@ type MenuItemProps = {
   text: string;
   iconSrc: string;
   href: string;
-  isActive: boolean;
+  isActive?: boolean;
   isCollapsed: boolean;
 };
 
@@ -15,7 +15,7 @@ export function MenuItemLink({
   text,
   href,
   iconSrc,
-  isActive,
+  isActive = false,
   isCollapsed,
 }: MenuItemProps) {
   return (

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,11 +79,11 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              href="mailto:support@prolog-app.com?subject=Support%20Request"
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
## Details

- This PR replaces the support button with a `MenuItemLink` in order to test with Cypress. We cannot test if a client's mail app is opened after the click. We can only test if the href is correctly set on the link. The alternative may be to wrap the button with a form or use jest to spy on the click handler and track if it's clicked. After research, I chose this to be the easiest implementation.

## Screenshots

N/A, verified extensively manually.
