### PR TITLE
Fix navigation logo when switching to mobile

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -50,6 +50,20 @@ describe("Sidebar Navigation", () => {
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
     });
+
+    it("shows large logo when switching to landscape while navigation is collapsed", () => {
+      // collapse sidebar
+      cy.get("nav").contains("Collapse").click();
+      // verify the right icon is rendered
+      cy.get("img[src='/icons/logo-small.svg']").should("be.visible");
+      cy.get("img[src='/icons/logo-large.svg']").should("not.be.visible");
+
+      // switch viewport to landscape mode
+      cy.viewport(900, 1025);
+      // verify the right icon is rendered
+      cy.get("img[src='/icons/logo-large.svg']").should("be.visible");
+      cy.get("img[src='/icons/logo-small.svg']").should("not.be.visible");
+    });
   });
 
   context("mobile resolution", () => {

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -22,6 +22,7 @@
       width: 5.1875rem;
 
       .logo {
+        content: url("/icons/logo-small.svg");
         width: 1.4375rem;
       }
     }
@@ -52,6 +53,7 @@
 
 .logo {
   width: 7.375rem;
+  content: url("/icons/logo-large.svg");
 
   @media (min-width: breakpoint.$desktop) {
     margin: space.$s0 space.$s4;

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -20,10 +20,6 @@
   &.isCollapsed {
     @media (min-width: breakpoint.$desktop) {
       width: 5.1875rem;
-
-      .logo {
-        width: 1.4375rem;
-      }
     }
   }
 }
@@ -51,10 +47,31 @@
 }
 
 .logo {
+  @media (min-width: breakpoint.$desktop) {
+    margin: space.$s0 space.$s4;
+    width: 1.4375rem;
+  }
+}
+
+.logoLarge {
+  composes: logo;
   width: 7.375rem;
 
   @media (min-width: breakpoint.$desktop) {
-    margin: space.$s0 space.$s4;
+    &.isCollapsed {
+      display: none;
+    }
+  }
+}
+
+.logoSmall {
+  composes: logo;
+  display: none;
+
+  @media (min-width: breakpoint.$desktop) {
+    &.isCollapsed {
+      display: block;
+    }
   }
 }
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -36,13 +36,21 @@ export function SidebarNavigation() {
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
+            src={"/icons/logo-large.svg"}
             alt="logo"
-            className={styles.logo}
+            className={classNames(
+              styles.logoLarge,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
+          />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={"/icons/logo-small.svg"}
+            alt="logo"
+            className={classNames(
+              styles.logoSmall,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
           />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -35,15 +35,7 @@ export function SidebarNavigation() {
       >
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
-            alt="logo"
-            className={styles.logo}
-          />
+          <img alt="logo" className={styles.logo} />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}
             className={styles.menuButton}
@@ -79,11 +71,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              href="mailto:support@prolog-app.com?subject=Support%20Request"
+              isActive={false}
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
## Details

- this fixes the bug where a user switches device orientation in a way that results in a change from desktop to mobile mode the small logo is shown instead of the large one.

## Screenshots
![chrome_2023-12-02_14-04-36](https://github.com/profydev/prolog-app-cbtsao47/assets/16598376/e4b97478-0ed6-4c8c-92f7-7972af92a2e6)
