### PR TITLE
fix: update pagination text color

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
## Details

- this updates the pagination color according to the figma spec.

## Screenshots
![image](https://github.com/profydev/prolog-app-cbtsao47/assets/16598376/fe7e7269-5b00-4f0b-8f61-cdcff84f5d5e)
